### PR TITLE
add missing proxy.conf file for secure-monolith

### DIFF
--- a/bundles/kubernetes-101/workshop/kubernetes/nginx/proxy.conf
+++ b/bundles/kubernetes-101/workshop/kubernetes/nginx/proxy.conf
@@ -1,0 +1,15 @@
+upstream local {
+    server localhost;
+}
+
+server {
+    listen 443;
+    ssl    on;
+
+    ssl_certificate     /etc/tls/cert.pem;
+    ssl_certificate_key /etc/tls/key.pem;
+
+    location / {
+        proxy_pass http://local;
+    }
+}


### PR DESCRIPTION
In the kubernetes-101 workshop there is a [tutorial](https://github.com/GoogleCloudPlatform/kubernetes-workshops/blob/master/bundles/kubernetes-101/workshop/labs/managing-application-configurations-and-secrets.md#tutorial-creating-configmaps) where we create a `secure-monolith` pod which hides an app behinf an nginx reverse proxy. 

The tutorial instructs us to create a config map using missing `proxy.conf` file. This PR adds a configuration file that works with the given steps.